### PR TITLE
Missing buildout options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ with a buildout like so::
     [gunicorn]
     recipe = zc.recipe.egg:scripts
     eggs = 
-        ${test:eggs}
+        ${tests:eggs}
         gunicorn 
     
 Start the application with::

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ To run the example application and tests coming with this package run
 with a buildout like so:: 
 
     [buildout]
+    develop = .
     parts = gunicorn   
     
     [tests]


### PR DESCRIPTION
Added the missing 'develop = .' to tell buildout to pick up the current package instead of searching PyPI.